### PR TITLE
use rc 0 when CTest has failing tests

### DIFF
--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -100,6 +100,9 @@ class CmakeTestTask(TaskExtensionPoint):
                 rerun += 1
                 continue
 
+            # if CTest reports failing tests the return code should still be 0
+            if rc.returncode == 8:
+                return 0
             return rc.returncode
 
     def _get_configuration_from_cmake(self, build_base):


### PR DESCRIPTION
While I couldn't find any documentation about it `CTest` returns `8` when tests are failing. Since tests failures should not be considered an "error" in terms of invoking the `test` verb that case is handled differently. This unifies the return value semantic across other types.

Before the failing bridge test made the build fail: https://ci.ros2.org/view/colcon/job/colcon_ci_packaging_linux-aarch64/5/
After the failing bridge test make the build only unstable: https://ci.ros2.org/view/colcon/job/colcon_ci_packaging_linux-aarch64/7/