### PR TITLE
add --cmake-target and --cmake-clean-first options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 environment:
   matrix:
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   # install_requires


### PR DESCRIPTION
Add new options:
* to build a specific target (`--cmake-build-target`) instead of the default ones and
* to `clean` before building (`--cmake-clean-first`).