### PR TITLE
Document --cmake-args needs a quoted space before an argument with a dash on windows

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -36,10 +36,12 @@ class CmakeBuildTask(TaskExtensionPoint):
         parser.add_argument(
             '--cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Arbitrary arguments which are passed to all CMake projects '
-            '(Args that start with "-" must be prefixed with a space. '
-            'If using bash then use `\ `, e.g.: `--cmake-args \ -Dvar=val`. '
-            'If using Windows cmd then use: `--cmake-args " -Dvar=var"`)')
+            help='Arbitrary arguments which are passed to all CMake projects. '
+            'Args that start with "-" must be prefixed with a space. '
+            'If using bash then use'
+            '\n\t--cmake-args \ -Dvar=val\n'
+            'If using Windows cmd then use'
+            '\n\t--cmake-args " -Dvar=val"\n')
         parser.add_argument(
             '--cmake-clean-cache',
             action='store_true',

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -36,9 +36,9 @@ class CmakeBuildTask(TaskExtensionPoint):
         parser.add_argument(
             '--cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Arbitrary arguments which are passed to all CMake projects. '
-            'Args that start with "-" must be prefixed with a space. '
-            '\n\t--cmake-args " -Dvar=val"\n')
+            help='Pass arguments to all CMake projects. Every arg starting '
+            'with a dash must be prefixed by a space,\n'
+            'e.g. --cmake-args " -Dvar=val"')
         parser.add_argument(
             '--cmake-clean-cache',
             action='store_true',

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -38,9 +38,6 @@ class CmakeBuildTask(TaskExtensionPoint):
             nargs='*', metavar='*', type=str.lstrip,
             help='Arbitrary arguments which are passed to all CMake projects. '
             'Args that start with "-" must be prefixed with a space. '
-            'If using bash then use'
-            '\n\t--cmake-args \ -Dvar=val\n'
-            'If using Windows cmd then use'
             '\n\t--cmake-args " -Dvar=val"\n')
         parser.add_argument(
             '--cmake-clean-cache',

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -37,8 +37,9 @@ class CmakeBuildTask(TaskExtensionPoint):
             '--cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help='Arbitrary arguments which are passed to all CMake projects '
-            '(args which start with a dash must be prefixed with an escaped '
-            'space `\ `, e.g.: `--cmake-args \ -Dvar=val`)')
+            '(Args that start with "-" must be prefixed with a space. '
+            'If using bash then use `\ `, e.g.: `--cmake-args \ -Dvar=val`. '
+            'If using Windows cmd then use: `--cmake-args " -Dvar=var"`)')
         parser.add_argument(
             '--cmake-clean-cache',
             action='store_true',

--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -26,9 +26,9 @@ class CmakeTestTask(TaskExtensionPoint):
         parser.add_argument(
             '--ctest-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Arbitrary arguments which are passed to all CTest projects. '
-            'Args that start with "-" must be prefixed with a space. '
-            '\n\t--ctest-args " -L" label\n')
+            help='Pass arguments to all CTest projects. Every arg starting '
+            'with a dash must be prefixed by a space,\n'
+            'e.g. --ctest-args " -L" label')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
         pkg = self.context.pkg

--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -26,9 +26,12 @@ class CmakeTestTask(TaskExtensionPoint):
         parser.add_argument(
             '--ctest-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Arbitrary arguments which are passed to all CTest projects '
-            '(args which start with a dash must be prefixed with an escaped '
-            'space `\ `, e.g.: `--ctest-args \ -L label`)')
+            help='Arbitrary arguments which are passed to all CTest projects. '
+            'Args that start with "-" must be prefixed with a space. '
+            'If using bash then use'
+            '\n\t--ctest-args \ -L label\n'
+            'If using Windows cmd then use'
+            '\n\t--ctest-args " -L" label\n')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
         pkg = self.context.pkg

--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -28,9 +28,6 @@ class CmakeTestTask(TaskExtensionPoint):
             nargs='*', metavar='*', type=str.lstrip,
             help='Arbitrary arguments which are passed to all CTest projects. '
             'Args that start with "-" must be prefixed with a space. '
-            'If using bash then use'
-            '\n\t--ctest-args \ -L label\n'
-            'If using Windows cmd then use'
             '\n\t--ctest-args " -L" label\n')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102


### PR DESCRIPTION
The help text for `--cmake-args` now says to quote a space if using cmd on windows.

```
Arguments for 'cmake' packages:
  --cmake-args [* [* ...]]
                        Arbitrary arguments which are passed to all CMake
                        projects. Args that start with "-" must be prefixed
                        with a space. If using bash then use
                                --cmake-args \ -Dvar=val
                        If using Windows cmd then use
                                --cmake-args " -Dvar=val"
```

```
Arguments for 'cmake' packages:
  --ctest-args [* [* ...]]
                        Arbitrary arguments which are passed to all CTest
                        projects. Args that start with "-" must be prefixed
                        with a space. If using bash then use
                                --ctest-args \ -L label
                        If using Windows cmd then use
                                --ctest-args " -L" label
```

connects to colcon/colcon-cmake#6