### PR TITLE
check for project name

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -76,6 +76,19 @@ class CmakeBuildTask(TaskExtensionPoint):
         rc = await self._reconfigure(args, env)
         if rc and rc.returncode:
             return rc.returncode
+
+        # ensure that CMake cache contains the project name
+        project_name = get_variable_from_cmake_cache(
+            args.build_base, 'CMAKE_PROJECT_NAME')
+        if project_name is None:
+            # if not the CMake code hasn't called project() and can't be built
+            logger.warn(
+                "Could not build CMake package '{args.name}' because the "
+                "CMake cache has no 'CMAKE_PROJECT_NAME' variable"
+                .format_map(locals())
+            )
+            return
+
         rc = await self._build(args, env)
         if rc.returncode:
             return rc.returncode


### PR DESCRIPTION
If a package doesn't set the project name in CMake it can't be built with `cmake --build`.

E.g. [geometry2](https://github.com/ros/geometry2/blob/9aa34bf83a9dbcd5bff4c8e1dda2690ae9900eff/test_tf2/CMakeLists.txt#L3-L7).