### PR TITLE
fix CMAKE_MODULE_PATH env var

### DIFF
--- a/colcon_cmake/environment/cmake_module_path.py
+++ b/colcon_cmake/environment/cmake_module_path.py
@@ -10,7 +10,7 @@ from colcon_core.shell import create_environment_hook
 
 
 class CmakeModulePathEnvironment(EnvironmentExtensionPoint):
-    """Extend the `CMAKE_PREFIX_PATH` variable to find CMake modules."""
+    """Extend the `CMAKE_MODULE_PATH` variable to find CMake modules."""
 
     def __init__(self):  # noqa: D107
         super().__init__()
@@ -21,12 +21,17 @@ class CmakeModulePathEnvironment(EnvironmentExtensionPoint):
         hooks = []
 
         logger.log(1, "checking '%s' for CMake module files" % prefix_path)
+        count = 0
         for dirpath, _, filenames in os.walk(str(prefix_path)):
             for filename in filenames:
                 if filename.startswith('Find') and filename.endswith('.cmake'):
+                    count += 1
                     hooks += create_environment_hook(
-                        'cmake_module_path', prefix_path / dirpath,
-                        pkg_name, 'CMAKE_MODULE_PATH', '', mode='prepend')
+                        'cmake_module_path' +
+                        (str(count) if count > 1 else ''),
+                        prefix_path, pkg_name, 'CMAKE_MODULE_PATH',
+                        os.path.relpath(dirpath, start=str(prefix_path)),
+                        mode='prepend')
                     break
 
         return hooks


### PR DESCRIPTION
Currently the environment hooks are being generated in (depending in where the CMake module was found):

```
<prefix>/share/<pkgname>/cmake/Modules/share/<pkgname>/hook/cmake_module_path.bat
```

and the appended path points to:

```
<prefix>
```

With this patch the location of the environment hook is not nested anymore:

```
<prefix>/share/<pkgname>/hook/cmake_module_path.bat
```

and the appended path is the directory containing the CMake module:

```
<prefix>/share/<pkgname>/cmake/Modules
```

The first fix is just cosmetic. The second one avoid cross-talk between packages (one extending the module path and another one benefiting from it).

Additionally the patch fixes the case where a package installs multiple CMake module into different location. Before the last hook was overwriting all previous ones.