### PR TITLE
fix duplicate CMAKE_MODULE_PATH hooks in case of a merged install

### DIFF
--- a/colcon_cmake/environment/cmake_module_path.py
+++ b/colcon_cmake/environment/cmake_module_path.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import os
+from collections import OrderedDict
 
 from colcon_core.environment import EnvironmentExtensionPoint
 from colcon_core.environment import logger
@@ -18,20 +18,83 @@ class CmakeModulePathEnvironment(EnvironmentExtensionPoint):
             EnvironmentExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
     def create_environment_hooks(self, prefix_path, pkg_name):  # noqa: D102
-        hooks = []
+        hooks = OrderedDict()
 
         logger.log(1, "checking '%s' for CMake module files" % prefix_path)
-        count = 0
-        for dirpath, _, filenames in os.walk(str(prefix_path)):
-            for filename in filenames:
-                if filename.startswith('Find') and filename.endswith('.cmake'):
-                    count += 1
-                    hooks += create_environment_hook(
-                        'cmake_module_path' +
-                        (str(count) if count > 1 else ''),
-                        prefix_path, pkg_name, 'CMAKE_MODULE_PATH',
-                        os.path.relpath(dirpath, start=str(prefix_path)),
-                        mode='prepend')
-                    break
+        for path in self._get_potential_cmake_module_paths(
+            prefix_path, pkg_name
+        ):
+            if not path.is_dir():
+                continue
+            # skip paths which are the same but only differ in case
+            if any(path.samefile(p) for p in hooks.keys()):
+                continue
 
-        return hooks
+            for filename in path.iterdir():
+                if not filename.is_file():
+                    continue
+                if (
+                    filename.name.startswith('Find') and
+                    filename.name.endswith('.cmake')
+                ):
+                    hooks[path] = create_environment_hook(
+                        'cmake_module_path' +
+                        (str(len(hooks)) if hooks else ''),
+                        prefix_path, pkg_name, 'CMAKE_MODULE_PATH',
+                        str(path.relative_to(prefix_path)),
+                        mode='prepend')
+
+        return hooks.values()
+
+    def _get_potential_cmake_module_paths(self, prefix_path, pkg_name):
+        paths = []
+        # see https://cmake.org/cmake/help/latest/command/find_package.html
+        # for the list of locations considered by default / convention
+
+        # <prefix>/ (W)
+        # <prefix>/(cmake|CMake)/ (W)
+        # skipped due to not being package specific in the --merge-install case
+
+        # <prefix>/<name>*/ (W)
+        # <prefix>/<name>*/(cmake|CMake)/ (W)
+        # skipped non-FHS compliant directories
+
+        # <prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/ (U)
+        # skipped arch specific directory since arch is unknown here
+        paths.append(prefix_path / 'lib64' / 'cmake' / pkg_name)
+        paths.append(prefix_path / 'lib32' / 'cmake' / pkg_name)
+        paths.append(prefix_path / 'libx32' / 'cmake' / pkg_name)
+        paths.append(prefix_path / 'lib' / 'cmake' / pkg_name)
+        paths.append(prefix_path / 'share' / 'cmake' / pkg_name)
+        # <prefix>/(lib/<arch>|lib*|share)/<name>*/ (U)
+        # skipped arch specific directory since arch is unknown here
+        paths.append(prefix_path / 'lib64' / pkg_name)
+        paths.append(prefix_path / 'lib32' / pkg_name)
+        paths.append(prefix_path / 'libx32' / pkg_name)
+        paths.append(prefix_path / 'lib' / pkg_name)
+        paths.append(prefix_path / 'share' / pkg_name)
+        # <prefix>/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/ (U)
+        # skipped arch specific directory since arch is unknown here
+        paths.append(prefix_path / 'lib64' / pkg_name / 'cmake')
+        paths.append(prefix_path / 'lib32' / pkg_name / 'cmake')
+        paths.append(prefix_path / 'libx32' / pkg_name / 'cmake')
+        paths.append(prefix_path / 'lib' / pkg_name / 'cmake')
+        paths.append(prefix_path / 'lib64' / pkg_name / 'CMake')
+        paths.append(prefix_path / 'lib32' / pkg_name / 'CMake')
+        paths.append(prefix_path / 'libx32' / pkg_name / 'CMake')
+        paths.append(prefix_path / 'lib' / pkg_name / 'CMake')
+        paths.append(prefix_path / 'share' / pkg_name / 'cmake')
+        paths.append(prefix_path / 'share' / pkg_name / 'CMake')
+
+        # <prefix>/<name>*/(lib/<arch>|lib*|share)/cmake/<name>*/ (W/U)
+        # <prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/ (W/U)
+        # <prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/ (W/U)
+        # <prefix>/<name>.framework/Resources/ (A)
+        # <prefix>/<name>.framework/Resources/CMake/ (A)
+        # <prefix>/<name>.framework/Versions/*/Resources/ (A)
+        # <prefix>/<name>.framework/Versions/*/Resources/CMake/ (A)
+        # <prefix>/<name>.app/Contents/Resources/ (A)
+        # <prefix>/<name>.app/Contents/Resources/CMake/ (A)
+        # skipped non-FHS compliant directories
+
+        return paths

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,3 +1,4 @@
+app
 argcomplete
 args
 basepath
@@ -9,6 +10,7 @@ config
 cpu
 ctest
 dict
+fhs
 github
 https
 jobserver


### PR DESCRIPTION
Follow up of #19. See the problem description in [this comment](https://github.com/colcon/colcon-cmake/pull/19#issuecomment-398828746).

This should cut the number of sourced scripts by half (in the case of non-isolated installs with a ROS 2 workspace).