### PR TITLE
consider sched_getaffinity when limiting parallel jobs

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -290,6 +290,11 @@ class CmakeBuildTask(TaskExtensionPoint):
             return []
         # Use the number of CPU cores
         jobs = os.cpu_count()
+        try:
+            # consider restricted set of CPUs if applicable
+            jobs = min(jobs, len(os.sched_getaffinity(0)))
+        except AttributeError:
+            pass
         if jobs is None:
             # the number of cores can't be determined
             return []

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,6 +9,7 @@ completers
 ctest
 ctests
 dcmake
+getaffinity
 github
 https
 iterdir


### PR DESCRIPTION
Since some CI providers like Circle CI limit the CPUs allocated to the container it is beneficial to use that information for the upper limit of jobs.

Similar to colcon/colcon-parallel-executor#17.