### PR TITLE
add assert message if build_base doesn't exist

### DIFF
--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -38,7 +38,8 @@ class CmakeTestTask(TaskExtensionPoint):
         logger.info(
             "Testing CMake package in '{args.path}'".format_map(locals()))
 
-        assert os.path.exists(args.build_base)
+        assert os.path.exists(args.build_base), \
+            'Has this package been built before?'
 
         try:
             env = await get_command_environment(


### PR DESCRIPTION
To provide a better error message to the user.

E.g. in this case: https://ci.ros2.org/view/nightly/job/nightly_linux-centos_repeated/4/console#console-section-30