### PR TITLE
cmake/build.py: support Visual Studio 16 2019

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -151,6 +151,7 @@ class CmakeBuildTask(TaskExtensionPoint):
                     'VisualStudioVersion is not set, '
                     'please run within a Visual Studio Command Prompt.')
             supported_vsv = {
+                '16.0': 'Visual Studio 16 2019',
                 '15.0': 'Visual Studio 15 2017 Win64',
                 '14.0': 'Visual Studio 14 2015 Win64',
             }


### PR DESCRIPTION
When trying to build a cmake package with cmake 3.14 and Visual Studio 2019, I see the following error:

~~~
Traceback (most recent call last):
  File "c:\users\scpet\desktop\ws\py_colcon_venv\lib\site-packages\colcon_core\executor\__init__.py", line 91, in __call__
    rc = await self.task(*args, **kwargs)
  File "c:\users\scpet\desktop\ws\py_colcon_venv\lib\site-packages\colcon_core\task\__init__.py", line 92, in __call__
    return await task_method(*args, **kwargs)
  File "c:\users\scpet\desktop\ws\py_colcon_venv\lib\site-packages\colcon_cmake\task\cmake\build.py", line 85, in build
    rc = await self._reconfigure(args, env)
  File "c:\users\scpet\desktop\ws\py_colcon_venv\lib\site-packages\colcon_cmake\task\cmake\build.py", line 160, in _reconfigure
    .format_map(locals()))
RuntimeError: Unknown / unsupported VS version ''
~~~

I've added an entry for Visual Studio 2019 into `cmake/build.py`, but the format is different than previous versions due to changes discussed in the [cmake 3.14 release notes](https://cmake.org/cmake/help/v3.14/release/3.14.html#generators):

> The VS 2019 generator differs from generators for earlier versions in that it does not provide variants that specify the target platform in the generator name. Instead [CMAKE_GENERATOR_PLATFORM](https://cmake.org/cmake/help/v3.14/variable/CMAKE_GENERATOR_PLATFORM.html#variable:CMAKE_GENERATOR_PLATFORM) must be used, e.g. through the `-A` command-line option. Furthermore, the default target platform (architecture) is now based on the *host* platform. The VS host toolset selection is now based on the host architecture as well.

So I've simply removed the architecture from the string, and it worked in my subsequent testing.