### PR TITLE
add test result extension for CTest result files

### DIFF
--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -28,13 +28,9 @@ class CtestTestResult(TestResultExtensionPoint):
 
     def get_test_results(self, basepath, *, collect_details):  # noqa: D102
         results = set()
-        # only consider direct subdirectories
-        for path in basepath.iterdir():
-            # check for the TAG file in a fixed relative path
-            if not path.is_dir():
-                continue
-            tag_file = path / 'Testing' / 'TAG'
-            if not tag_file.exists():
+        # check all 'TAG' files in a directory named 'Testing'
+        for tag_file in basepath.glob('**/Testing/TAG'):
+            if not tag_file.is_file():
                 continue
 
             # find the latest Test.xml file
@@ -42,7 +38,7 @@ class CtestTestResult(TestResultExtensionPoint):
             latest_xml_path = tag_file.parent / latest_xml_dir / 'Test.xml'
             if not latest_xml_path.exists():
                 logger.warn(
-                    "Skipping '{path}': could not find latest XML file "
+                    "Skipping '{tag_file}': could not find latest XML file "
                     "'{latest_xml_path}'".format_map(locals()))
                 continue
 

--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -1,0 +1,97 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+from xml.etree.ElementTree import ElementTree
+
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_test_result.test_result import Result
+from colcon_test_result.test_result import TestResultExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
+
+
+class CtestTestResult(TestResultExtensionPoint):
+    """
+    Collect the CTest results generated when testing a set of CMake packages.
+
+    It checks each direct subdirectory of the passed build base for a
+    'Testing/TAG' file.
+    The first line in that file contains the directory name of the latest
+    'Test.xml' result file relative to the 'Testing' directory.
+    """
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            TestResultExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def get_test_results(self, basepath, *, collect_details):  # noqa: D102
+        results = set()
+        # only consider direct subdirectories
+        for path in basepath.iterdir():
+            # check for the TAG file in a fixed relative path
+            if not path.is_dir():
+                continue
+            tag_file = path / 'Testing' / 'TAG'
+            if not tag_file.exists():
+                continue
+
+            # find the latest Test.xml file
+            latest_xml_dir = tag_file.read_text().splitlines()[0]
+            latest_xml_path = tag_file.parent / latest_xml_dir / 'Test.xml'
+            if not latest_xml_path.exists():
+                logger.warn(
+                    "Skipping '{path}': could not find latest XML file "
+                    "'{latest_xml_path}'".format_map(locals()))
+                continue
+
+            # parse the XML file
+            tree = ElementTree()
+            root = tree.parse(str(latest_xml_path))
+
+            # check if the root tag looks like a CTest file
+            if root.tag != 'Site':
+                logger.warn(
+                    "Skipping '{latest_xml_path}': the root tag is not 'Site'"
+                    .format_map(locals()))
+                continue
+
+            # look for a single 'Testing' child tag
+            children = root.getchildren()
+            if len(children) != 1:
+                logger.warn(
+                    "Skipping '{latest_xml_path}': 'Site' tag is expected to "
+                    '"have exactly one child'.format_map(locals()))
+                continue
+            if children[0].tag != 'Testing':
+                logger.warn(
+                    "Skipping '{latest_xml_path}': the child tag is not "
+                    "'Testing'".format_map(locals()))
+                continue
+
+            # collect information from all 'Test' tags
+            result = Result(str(latest_xml_path))
+            for child in children[0]:
+                if child.tag != 'Test':
+                    continue
+
+                result.test_count += 1
+
+                try:
+                    status = child.attrib['Status']
+                except KeyError:
+                    logger.warn(
+                        "Skipping '{latest_xml_path}': a 'test' tag lacks a "
+                        "'Status' attribute".format_map(locals()))
+                    break
+
+                if status == 'failed':
+                    result.failure_count += 1
+                elif status == 'notrun':
+                    result.skipped_count += 1
+                elif status != 'passed':
+                    result.error_count += 1
+            else:
+                results.add(result)
+        return results

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,8 @@ colcon_core.task.build =
     cmake = colcon_cmake.task.cmake.build:CmakeBuildTask
 colcon_core.task.test =
     cmake = colcon_cmake.task.cmake.test:CmakeTestTask
+colcon_test_result.test_result =
+    ctest = colcon_cmake.test_result.ctest:CtestTestResult
 
 [flake8]
 import-order-style = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
   colcon-core
   # to set an environment variable when a package installs a library
   colcon-library-path
+  colcon-test-result>=0.3.3
 packages = find:
 tests_require =
   flake8

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-cmake]
 No-Python2:
-Depends3: python3-colcon-core, python3-colcon-library-path
+Depends3: python3-colcon-core, python3-colcon-library-path, python3-colcon-test-result (>= 0.3.3)
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,7 +9,9 @@ completers
 ctest
 ctests
 dcmake
+etree
 getaffinity
+getchildren
 github
 https
 iterdir
@@ -23,6 +25,7 @@ modline
 msbuild
 nargs
 noqa
+notrun
 pathlib
 plugin
 prepend


### PR DESCRIPTION
Closes #40. Requires colcon/colcon-test-result#20.

Before merging a version dependency on the upcoming `colcon-test-result` package needs to be added.