### PR TITLE
Provide options for generator override on Windows.

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -144,7 +144,8 @@ class CmakeBuildTask(TaskExtensionPoint):
         cmake_args = [args.path]
         cmake_args += (args.cmake_args or [])
         cmake_args += ['-DCMAKE_INSTALL_PREFIX=' + args.install_base]
-        if os.name == 'nt':
+        generator = get_generator(args.build_base, args.cmake_args)
+        if os.name == 'nt' and generator is None:
             vsv = get_visual_studio_version()
             if vsv is None:
                 raise RuntimeError(


### PR DESCRIPTION
Beginning from [`Visual Studio 2017 15.4`](https://devblogs.microsoft.com/cppblog/cmake-support-in-visual-studio/), the toolchain comes with `CMake` and `Ninja` built-in support. It would be great to see Windows developers can have the free choice on what generator to use. This pull request is to unblock the hard-coded decision in `colcon-cmake` and allow developers to pass `--cmake-args -G Ninja` to specify the generator by their choices.