### PR TITLE
cmake_install always invokes --build --target install

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -321,14 +321,8 @@ class CmakeBuildTask(TaskExtensionPoint):
         if multi_configuration_generator:
             cmd += ['--config', self._get_configuration(args)]
         else:
-            # Add make/ninja arguments for the number of job threads to use.
             job_args = self._get_make_arguments()
             if job_args:
-                # Add arguments for the number of job threads to use
-                # Arguably, _get_make_arguments() should be be configured to
-                # return arguments based on the current generator, not just for
-                # make (and ninja by coincidence). The '--' extension may be
-                # better returned from _get_make_arguments()
                 cmd += ['--'] + job_args
         return await check_call(
             self.context, cmd, cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -313,27 +313,11 @@ class CmakeBuildTask(TaskExtensionPoint):
     async def _install(self, args, env):
         self.progress('install')
 
-        generator = get_generator(args.build_base)
-        if 'Visual Studio' not in generator:
-            if CMAKE_EXECUTABLE is None:
-                raise RuntimeError("Could not find 'cmake' executable")
-            cmd = [
+        if CMAKE_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cmake' executable")
+        return await check_call(
+            self.context,
+            [
                 CMAKE_EXECUTABLE, '--build', args.build_base,
-                '--target', 'install']
-            job_args = self._get_make_arguments()
-            if job_args:
-                cmd += ['--'] + job_args
-            return await check_call(
-                self.context, cmd, cwd=args.build_base, env=env)
-        else:
-            if MSBUILD_EXECUTABLE is None:
-                raise RuntimeError("Could not find 'msbuild' executable")
-            install_project_file = get_project_file(args.build_base, 'INSTALL')
-            return await check_call(
-                self.context,
-                [
-                    MSBUILD_EXECUTABLE,
-                    '/p:Configuration=' +
-                    self._get_configuration(args),
-                    install_project_file],
-                env=env)
+                '--target', 'install'],
+            cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -9,12 +9,10 @@ import re
 from colcon_cmake.task.cmake import CMAKE_EXECUTABLE
 from colcon_cmake.task.cmake import get_buildfile
 from colcon_cmake.task.cmake import get_generator
-from colcon_cmake.task.cmake import get_project_file
 from colcon_cmake.task.cmake import get_variable_from_cmake_cache
 from colcon_cmake.task.cmake import get_visual_studio_version
 from colcon_cmake.task.cmake import has_target
 from colcon_cmake.task.cmake import is_multi_configuration_generator
-from colcon_cmake.task.cmake import MSBUILD_EXECUTABLE
 from colcon_core.environment import create_environment_scripts
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -315,9 +315,13 @@ class CmakeBuildTask(TaskExtensionPoint):
 
         if CMAKE_EXECUTABLE is None:
             raise RuntimeError("Could not find 'cmake' executable")
+        call_args = [
+            CMAKE_EXECUTABLE, '--build', args.build_base,
+            '--target', 'install']
+        multi_configuration_generator = is_multi_configuration_generator(
+            args.build_base, args.cmake_args)
+        if multi_configuration_generator:
+            call_args.append('--config')
+            call_args.append(self._get_configuration(args))
         return await check_call(
-            self.context,
-            [
-                CMAKE_EXECUTABLE, '--build', args.build_base,
-                '--target', 'install'],
-            cwd=args.build_base, env=env)
+            self.context, call_args, cwd=args.build_base, env=env)


### PR DESCRIPTION
Removed special case code for Visual Studio generator using MSBUILD. "cmake --build" with "--target install" has the same effect and removed the need for special case code.