### PR TITLE
Use 'cmake --install' where available

### DIFF
--- a/colcon_cmake/__init__.py
+++ b/colcon_cmake/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-__version__ = '0.2.15'
+__version__ = '0.2.16'

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -221,10 +221,10 @@ def _parse_cmake_version(version_str):
     :rtype (int, int, int, str)
     """
     # Version number is on the first line. We can ignore anything else.
+    ver_re_str = \
+        r'^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(.*))?\s*.*$'
     if version_str and len(version_str):
-        ver_match = re.match(
-            r'^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(.*))?\s*.*$',
-            version_str)
+        ver_match = re.match(ver_re_str, version_str)
         if ver_match:
             return (int(ver_match.group(1)), int(ver_match.group(2)),
                     int(ver_match.group(3)), ver_match.group(4))

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -240,26 +240,6 @@ def get_cmake_version():
     return _cached_cmake_version
 
 
-def parse_cmake_version_string(version_string):
-    """
-    Parse the given CMake version string.
-
-    This is for internal use and testing.
-
-    Expects strings of the form 'cmake version 3.15.1'.
-
-    :param str version_string: The version string to parse.
-    :returns: The parsed version string or None on failure to parse.
-    :rtype pkg_resources.extern.packaging.version.Version
-    """
-    # Extract just the version part of the string.
-    ver_re_str = r'^(?:.*[ \t])?(\d+\.\d+\.\d+).*'
-    ver_match = re.match(ver_re_str, version_string)
-    if ver_match:
-        return parse_version(ver_match.group(1))
-    return None
-
-
 def _parse_cmake_version():
     """
     Parse the CMake version printed by `CMAKE_EXECUTABLE --version`.
@@ -277,5 +257,23 @@ def _parse_cmake_version():
         lines = output.decode().splitlines()
         if lines:
             # Parse just the version part of the string.
-            return parse_cmake_version_string(lines[0])
+            return _parse_cmake_version_string(lines[0])
+    return None
+
+
+def _parse_cmake_version_string(version_string):
+    """
+    Parse the given CMake version string.
+
+    Expects strings of the form 'cmake version 3.15.1'.
+
+    :param str version_string: The version string to parse.
+    :returns: The parsed version string or None on failure to parse.
+    :rtype pkg_resources.extern.packaging.version.Version
+    """
+    # Extract just the version part of the string.
+    ver_re_str = r'^(?:.*[ \t])?(\d+\.\d+\.\d+).*'
+    ver_match = re.match(ver_re_str, version_string)
+    if ver_match:
+        return parse_version(ver_match.group(1))
     return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -215,24 +215,22 @@ def get_visual_studio_version():
 """
 Global variable for the cached CMake version number.
 
-When valid, this will be of pkg_resources.extern.packaging.version.Version
-It may also have a boolean value False when the CMake version has failed
-to parse.
+When valid, this will be a pkg_resources.extern.packaging.version.Version.
+It may also have a boolean value False when the CMake version could not be
+determined to avoid trying to determine it again.
 """
 _cached_cmake_version = None
 
 
 def get_cmake_version():
     """
-    Get the cached CMake version number if available and successfully parsed.
+    Get the CMake version.
 
-    The result is None when a version number is not available or cannot be
-    parsed.
+    The function caches the result on the first invocation and reused that on
+    subsequent invocations.
+    The result is None when a version number could not be determined.
 
-    This may occur if CMake is not present, is a very old version or if a newer
-    changes the output format.
-
-    :returns: The version as parsed by the pkg_resources package
+    :returns: The version as reported by `CMAKE_EXECUTABLE --version`, or None
     :rtype pkg_resources.extern.packaging.version.Version
     """
     global _cached_cmake_version
@@ -262,23 +260,9 @@ def get_cmake_version():
 
 def _parse_cmake_version():
     """
-    Parse the CMake version number by running `cmake --version`.
+    Parse the CMake version printed by `CMAKE_EXECUTABLE --version`.
 
-    The version number is parse from the output of 'cmake --version' and is
-    expected in the form 'cmake version #.#.#' where each '#' character
-    represents part of the version number.
-
-    Additional text may follow, however only the first line is parsed.
-
-    Parsing is performed by the pkg_resources package and the returned object
-    is a Version object from that package.
-
-    This function blocks on the execution of cmake and should only be used to
-    cache the CMake version number.
-
-    External API users should use get_cmake_version()
-
-    :returns: The version as parsed by the pkg_resources package
+    :returns: The version parsed by pkg_resources.parse_version, or None
     :rtype pkg_resources.extern.packaging.version.Version
     """
     try:

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -263,7 +263,7 @@ def parse_cmake_version_string(version_string):
     :rtype pkg_resources.extern.packaging.version.Version
     """
     # Extract just the version part of the string.
-    ver_re_str = r'^.*(\d+\.\d+\.\d+).*'
+    ver_re_str = r'^(?:.*[ \t])?(\d+\.\d+\.\d+).*'
     ver_match = re.match(ver_re_str, version_string)
     if ver_match:
         return parse_version(ver_match.group(1))

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -234,5 +234,5 @@ async def get_cmake_version():
         ver_match = re.match(ver_re_str, ver_line, re.I)
         if ver_match:
             return parse_version(ver_match.group(1))
-    # Failed to extract parsable version number.
+    # Failed to parse version number.
     return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -236,27 +236,18 @@ def get_cmake_version():
     """
     global _cached_cmake_version
     if _cached_cmake_version is None:
-        # No value yet. Parse the version number.
-        _cached_cmake_version = _parse_cmake_version()
-        if _cached_cmake_version is not None:
-            # Success.
-            return _cached_cmake_version
-        # Failed to parse.
-        #
-        # Set _cached_cmake_version to False to prevent parsing again, but we
-        # can still return None as required.
-        _cached_cmake_version = False
-    # Have cached a previous result.
-    #
-    # Check if the previous result is a bool type.
-    #
-    # If so, this implies we've tried and failed to parse the version
-    # number and should return None.
-    #
-    # Otherwise return the cached value as is.
-    elif not isinstance(_cached_cmake_version, bool):
-        return _cached_cmake_version
-    return None
+        cmake_version = _parse_cmake_version()
+        if cmake_version is not None:
+            _cached_cmake_version = cmake_version
+        else:
+            # flag to avoid retrying on subsequent calls
+            _cached_cmake_version = False
+
+    if _cached_cmake_version is False:
+        # in case the CMake version could not be determined
+        return None
+
+    return _cached_cmake_version
 
 
 def _parse_cmake_version():

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pkg_resources import parse_version
 import re
 import shutil
 import subprocess
 
 from colcon_core.environment_variable import EnvironmentVariable
 from colcon_core.subprocess import check_output
+from pkg_resources import parse_version
 
 """Environment variable to override the CMake executable"""
 CMAKE_COMMAND_ENVIRONMENT_VARIABLE = EnvironmentVariable(

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -218,13 +218,17 @@ def _parse_cmake_version():
 
     The version number is parse from the output of 'cmake --version' and is
     expected in the form 'cmake version #.#.#' where each '#' character
-    represents part of the version number. Additional text may follow, however
-    only the first line is parsed. Parsing is performed by the pkg_resources
-    package and the returned object is a Version object from that package.
+    represents part of the version number.
+
+    Additional text may follow, however only the first line is parsed.
+
+    Parsing is performed by the pkg_resources package and the returned object
+    is a Version object from that package.
 
     This function blocks on the execution of cmake and should only be used to
-    cache the CMake version number. External API users should use
-    get_cmake_version()
+    cache the CMake version number.
+
+    External API users should use get_cmake_version()
 
     :returns: The version as parsed by the pkg_resources package
     :rtype pkg_resources.extern.packaging.version.Version
@@ -232,11 +236,10 @@ def _parse_cmake_version():
     try:
         output = subprocess.check_output([CMAKE_EXECUTABLE, '--version'])
         lines = output.decode().splitlines()
-        ver_line = lines[0] if lines and len(lines) else None
-        if ver_line:
+        if lines:
             # Extract just the version part of the string.
             ver_re_str = r'^(?:.*)(\d+\.\d+\..*)'
-            ver_match = re.match(ver_re_str, ver_line, re.I)
+            ver_match = re.match(ver_re_str, lines[0], re.I)
             if ver_match:
                 return parse_version(ver_match.group(1))
         return None
@@ -246,9 +249,12 @@ def _parse_cmake_version():
 
 
 # Global variable for the cached CMake version number.
+#
 # When valid, this will be of pkg_resources.extern.packaging.version.Version
 # It may also have a boolean value False when the cmake version has failed
-# to parse. This saves recurring parse failures.
+# to parse.
+#
+# This saves recurring parse failures.
 _cached_cmake_version = None
 
 
@@ -257,8 +263,10 @@ def get_cmake_version():
     Get the cached CMake version number if available and successfully parsed.
 
     The result is None when a version number is not available or cannot be
-    parsed. This may occur if CMake is not present, is a very old version or is
-    a newer version where the version number string output has changed.
+    parsed.
+
+    This may occur if CMake is not present, is a very old version or if a newer
+    changes the output format.
 
     :returns: The version as parsed by the pkg_resources package
     :rtype pkg_resources.extern.packaging.version.Version
@@ -270,12 +278,19 @@ def get_cmake_version():
         if _cached_cmake_version is not None:
             # Success.
             return _cached_cmake_version
-        # Failed to parse. Set _cached_cmake_version to False to prevent
-        # parsing again, but we can still return None as required.
+        # Failed to parse.
+        #
+        # Set _cached_cmake_version to False to prevent parsing again, but we
+        # can still return None as required.
         _cached_cmake_version = False
-    # Have cached a previous result. Check if the previous result is a bool
-    # type. If so, this implies we've tried and failed to parse the version
-    # number and should return None. Otherwise return the cached value as is.
+    # Have cached a previous result.
+    #
+    # Check if the previous result is a bool type.
+    #
+    # If so, this implies we've tried and failed to parse the version
+    # number and should return None.
+    #
+    # Otherwise return the cached value as is.
     elif not isinstance(_cached_cmake_version, bool):
         return _cached_cmake_version
     return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -250,6 +250,26 @@ def get_cmake_version():
     return _cached_cmake_version
 
 
+def parse_cmake_version_string(version_string):
+    """
+    Parse the given CMake version string.
+
+    This is for internal use and testing.
+
+    Expects strings of the form 'cmake version 3.15.1'.
+
+    :param str version_string: The version string to parse.
+    :returns: The parsed version string or None on failure to parse.
+    :rtype pkg_resources.extern.packaging.version.Version
+    """
+    # Extract just the version part of the string.
+    ver_re_str = r'^.*(\d+\.\d+\.\d+).*'
+    ver_match = re.match(ver_re_str, version_string)
+    if ver_match:
+        return parse_version(ver_match.group(1))
+    return None
+
+
 def _parse_cmake_version():
     """
     Parse the CMake version printed by `CMAKE_EXECUTABLE --version`.
@@ -266,9 +286,6 @@ def _parse_cmake_version():
     else:
         lines = output.decode().splitlines()
         if lines:
-            # Extract just the version part of the string.
-            ver_re_str = r'^(?:.*)(\d+\.\d+\..*)'
-            ver_match = re.match(ver_re_str, lines[0], re.I)
-            if ver_match:
-                return parse_version(ver_match.group(1))
+            # Parse just the version part of the string.
+            return parse_cmake_version_string(lines[0])
     return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 
 from colcon_core.environment_variable import EnvironmentVariable
 from colcon_core.subprocess import check_output
@@ -266,7 +267,12 @@ def _parse_cmake_version():
     :rtype pkg_resources.extern.packaging.version.Version
     """
     try:
-        output = subprocess.check_output([CMAKE_EXECUTABLE, '--version'])
+        output = subprocess.check_output(
+            [CMAKE_EXECUTABLE, '--version'], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print('Failed to determine CMake version: ' + e.output.decode(),
+              file=sys.stderr)
+    else:
         lines = output.decode().splitlines()
         if lines:
             # Extract just the version part of the string.
@@ -274,7 +280,4 @@ def _parse_cmake_version():
             ver_match = re.match(ver_re_str, lines[0], re.I)
             if ver_match:
                 return parse_version(ver_match.group(1))
-        return None
-    except subprocess.CalledProcessError:
-        return None
     return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -247,10 +247,15 @@ def _parse_cmake_version():
 
 # Global variable for the cached CMake version number.
 _cached_cmake_version = _parse_cmake_version()
+
+
 def get_cmake_version():
     """
-    Get the cached CMake version number or None if the version number is not
-    available and parsable.
+    Get the cached CMake version number if available and successfully parsed.
+
+    The result is None when a version number is not available or cannot be
+    parsed. This may occur if CMake is not present, is a very old version or is
+    a newer version where the version number string output has changed.
 
     :returns: The version as parsed by the pkg_resources package
     :rtype pkg_resources.extern.packaging.version.Version

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -272,7 +272,7 @@ def _parse_cmake_version_string(version_string):
     :rtype pkg_resources.extern.packaging.version.Version
     """
     # Extract just the version part of the string.
-    ver_re_str = r'^(?:.*[ \t])?(\d+\.\d+\.\d+).*'
+    ver_re_str = r'^(?:.*\s)?(\d+\.\d+\.\d+).*'
     ver_match = re.match(ver_re_str, version_string)
     if ver_match:
         return parse_version(ver_match.group(1))

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -222,7 +222,7 @@ def _parse_cmake_version(version_str):
     """
     # Version number is on the first line. We can ignore anything else.
     ver_re_str = \
-        r'^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(.*))?\s*.*$'
+        r'^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(\S+))?'
     if version_str and len(version_str):
         ver_match = re.match(ver_re_str, version_str)
         if ver_match:

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -228,11 +228,11 @@ async def get_cmake_version():
     output = await check_output([CMAKE_EXECUTABLE, '--version'])
     lines = output.decode().splitlines()
     ver_line = lines[0] if lines and len(lines) else None
-    if ver_line and len(ver_line):
+    if ver_line:
         # Extract just the version part of the string.
-        ver_re_str = r'^(?:cmake\s+version)?\s*(.*)$'
+        ver_re_str = r'^(?:.*)(\d+\.\d+\..*)'
         ver_match = re.match(ver_re_str, ver_line, re.I)
         if ver_match:
             return parse_version(ver_match.group(1))
-    # Failed: return invalid version
-    return parse_version('0.0.0')
+    # Failed to extract parsable version number.
+    return None

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -212,13 +212,13 @@ def get_visual_studio_version():
     return os.environ.get('VisualStudioVersion', None)
 
 
-# Global variable for the cached CMake version number.
-#
-# When valid, this will be of pkg_resources.extern.packaging.version.Version
-# It may also have a boolean value False when the cmake version has failed
-# to parse.
-#
-# This saves recurring parse failures.
+"""
+Global variable for the cached CMake version number.
+
+When valid, this will be of pkg_resources.extern.packaging.version.Version
+It may also have a boolean value False when the CMake version has failed
+to parse.
+"""
 _cached_cmake_version = None
 
 

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -223,7 +223,7 @@ def _parse_cmake_version(version_str):
     # Version number is on the first line. We can ignore anything else.
     if version_str and len(version_str):
         ver_match = re.match(
-            '^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(.*))?\s*.*$',
+            r'^(?:cmake\s+version)?\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:\-(.*))?\s*.*$',
             version_str)
         if ver_match:
             return (int(ver_match.group(1)), int(ver_match.group(2)),

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -267,7 +267,7 @@ def get_cmake_version():
     if _cached_cmake_version is None:
         # No value yet. Parse the version number.
         _cached_cmake_version = _parse_cmake_version()
-        if not _cached_cmake_version is None:
+        if _cached_cmake_version is not None:
             # Success.
             return _cached_cmake_version
         # Failed to parse. Set _cached_cmake_version to False to prevent

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -245,6 +245,7 @@ def _parse_cmake_version():
     # Failed to parse version number.
     return None
 
+
 # Global variable for the cached CMake version number.
 _cached_cmake_version = _parse_cmake_version()
 

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -217,36 +217,26 @@ def get_visual_studio_version():
 Global variable for the cached CMake version number.
 
 When valid, this will be a pkg_resources.extern.packaging.version.Version.
-It may also have a boolean value False when the CMake version could not be
-determined to avoid trying to determine it again.
+It may also be None when the CMake version could not be determined to avoid
+trying to determine it again.
 """
-_cached_cmake_version = None
+_cached_cmake_version = False
 
 
 def get_cmake_version():
     """
     Get the CMake version.
 
-    The function caches the result on the first invocation and reused that on
+    The function caches the result on the first invocation and reuses that on
     subsequent invocations.
-    The result is None when a version number could not be determined.
 
     :returns: The version as reported by `CMAKE_EXECUTABLE --version`, or None
+      when the version number could not be determined
     :rtype pkg_resources.extern.packaging.version.Version
     """
     global _cached_cmake_version
-    if _cached_cmake_version is None:
-        cmake_version = _parse_cmake_version()
-        if cmake_version is not None:
-            _cached_cmake_version = cmake_version
-        else:
-            # flag to avoid retrying on subsequent calls
-            _cached_cmake_version = False
-
     if _cached_cmake_version is False:
-        # in case the CMake version could not be determined
-        return None
-
+        _cached_cmake_version = _parse_cmake_version()
     return _cached_cmake_version
 
 

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -212,42 +212,6 @@ def get_visual_studio_version():
     return os.environ.get('VisualStudioVersion', None)
 
 
-def _parse_cmake_version():
-    """
-    Parse the CMake version number by running `cmake --version`.
-
-    The version number is parse from the output of 'cmake --version' and is
-    expected in the form 'cmake version #.#.#' where each '#' character
-    represents part of the version number.
-
-    Additional text may follow, however only the first line is parsed.
-
-    Parsing is performed by the pkg_resources package and the returned object
-    is a Version object from that package.
-
-    This function blocks on the execution of cmake and should only be used to
-    cache the CMake version number.
-
-    External API users should use get_cmake_version()
-
-    :returns: The version as parsed by the pkg_resources package
-    :rtype pkg_resources.extern.packaging.version.Version
-    """
-    try:
-        output = subprocess.check_output([CMAKE_EXECUTABLE, '--version'])
-        lines = output.decode().splitlines()
-        if lines:
-            # Extract just the version part of the string.
-            ver_re_str = r'^(?:.*)(\d+\.\d+\..*)'
-            ver_match = re.match(ver_re_str, lines[0], re.I)
-            if ver_match:
-                return parse_version(ver_match.group(1))
-        return None
-    except subprocess.CalledProcessError:
-        return None
-    return None
-
-
 # Global variable for the cached CMake version number.
 #
 # When valid, this will be of pkg_resources.extern.packaging.version.Version
@@ -293,4 +257,40 @@ def get_cmake_version():
     # Otherwise return the cached value as is.
     elif not isinstance(_cached_cmake_version, bool):
         return _cached_cmake_version
+    return None
+
+
+def _parse_cmake_version():
+    """
+    Parse the CMake version number by running `cmake --version`.
+
+    The version number is parse from the output of 'cmake --version' and is
+    expected in the form 'cmake version #.#.#' where each '#' character
+    represents part of the version number.
+
+    Additional text may follow, however only the first line is parsed.
+
+    Parsing is performed by the pkg_resources package and the returned object
+    is a Version object from that package.
+
+    This function blocks on the execution of cmake and should only be used to
+    cache the CMake version number.
+
+    External API users should use get_cmake_version()
+
+    :returns: The version as parsed by the pkg_resources package
+    :rtype pkg_resources.extern.packaging.version.Version
+    """
+    try:
+        output = subprocess.check_output([CMAKE_EXECUTABLE, '--version'])
+        lines = output.decode().splitlines()
+        if lines:
+            # Extract just the version part of the string.
+            ver_re_str = r'^(?:.*)(\d+\.\d+\..*)'
+            ver_match = re.match(ver_re_str, lines[0], re.I)
+            if ver_match:
+                return parse_version(ver_match.group(1))
+        return None
+    except subprocess.CalledProcessError:
+        return None
     return None

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -316,7 +316,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         if CMAKE_EXECUTABLE is None:
             raise RuntimeError("Could not find 'cmake' executable")
         cmd = [CMAKE_EXECUTABLE]
-        cmake_ver = await get_cmake_version()
+        cmake_ver = get_cmake_version()
         if cmake_ver and cmake_ver >= parse_version('3.15.0'):
             # CMake 3.15+ supports invoking `cmake --install [--config]
             # This only installs, whereas --build <dir> --target install will

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -313,27 +313,11 @@ class CmakeBuildTask(TaskExtensionPoint):
     async def _install(self, args, env):
         self.progress('install')
 
-        generator = get_generator(args.build_base)
-        if 'Visual Studio' not in generator:
-            if CMAKE_EXECUTABLE is None:
-                raise RuntimeError("Could not find 'cmake' executable")
-            cmd = [
+        if CMAKE_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cmake' executable")
+        return await check_call(
+            self.context,
+            [
                 CMAKE_EXECUTABLE, '--build', args.build_base,
-                '--target', 'install']
-            job_args = self._get_make_arguments()
-            if job_args:
-                cmd += ['--'] + job_args
-            return await check_call(
-                self.context, cmd, cwd=args.build_base, env=env)
-        else:
-            if MSBUILD_EXECUTABLE is None:
-                raise RuntimeError("Could not find 'msbuild' executable")
-            install_project_file = get_project_file(args.build_base, 'INSTALL')
-            return await check_call(
-                self.context,
-                [
-                    MSBUILD_EXECUTABLE,
-                    '/p:Configuration=' +
-                    self._get_configuration(args),
-                    install_project_file],
-                env=env)
+                '--target', 'install'],
+            cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -9,12 +9,10 @@ import re
 from colcon_cmake.task.cmake import CMAKE_EXECUTABLE
 from colcon_cmake.task.cmake import get_buildfile
 from colcon_cmake.task.cmake import get_generator
-from colcon_cmake.task.cmake import get_project_file
 from colcon_cmake.task.cmake import get_variable_from_cmake_cache
 from colcon_cmake.task.cmake import get_visual_studio_version
 from colcon_cmake.task.cmake import has_target
 from colcon_cmake.task.cmake import is_multi_configuration_generator
-from colcon_cmake.task.cmake import MSBUILD_EXECUTABLE
 from colcon_core.environment import create_environment_scripts
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -333,10 +333,8 @@ class CmakeBuildTask(TaskExtensionPoint):
         if multi_configuration_generator:
             cmd += ['--config', self._get_configuration(args)]
         else:
-            # Add make/ninja arguments for the number of job threads to use.
             job_args = self._get_make_arguments()
             if job_args:
-                # Add arguments for the number of job threads to use
                 cmd += ['--'] + job_args
         return await check_call(
             self.context, cmd, cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -325,13 +325,10 @@ class CmakeBuildTask(TaskExtensionPoint):
             cmd += ['--install', args.build_base]
         else:
             # Fallback to building the install target.
-            #
-            # Log an error if we are here because we failed to get a meaningful
-            # version number rather than simply using an unsupported version.
             if not cmake_ver:
-                logger.error(
-                    'Unable to determin CMake version. Fallback to building '
-                    'the install target in place of cmake --install.')
+                logger.warning(
+                    'Unable to determine CMake version, building the install'
+                    "target instead of invoking 'cmake --install'")
             cmd += ['--build', args.build_base, '--target', 'install']
 
         multi_configuration_generator = is_multi_configuration_generator(

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -319,11 +319,13 @@ class CmakeBuildTask(TaskExtensionPoint):
         cmake_ver = get_cmake_version()
         if cmake_ver and cmake_ver >= parse_version('3.15.0'):
             # CMake 3.15+ supports invoking `cmake --install [--config]
+            #
             # This only installs, whereas --build <dir> --target install will
             # build (again) then install.
             cmd += ['--install', args.build_base]
         else:
             # Fallback to building the install target.
+            #
             # Log an error if we are here because we failed to get a meaningful
             # version number rather than simply using an unsupported version.
             if not cmake_ver:

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -321,15 +321,14 @@ class CmakeBuildTask(TaskExtensionPoint):
             # CMake 3.15+ supports invoking `cmake --install [--config]
             # This only installs, whereas --build <dir> --target install will
             # build (again) then install.
-            call_args.extend(['--install', args.build_base])
+            call_args += ['--install', args.build_base]
         else:
             # Fallback to building the install target.
-            call_args.extend(['--build', args.build_base,
-                '--target', 'install'])
+            call_args += ['--build', args.build_base, '--target', 'install']
         # Add configuration for multi-config generators
         multi_configuration_generator = is_multi_configuration_generator(
             args.build_base, args.cmake_args)
         if multi_configuration_generator:
-            call_args.extend(['--config', self._get_configuration(args)])
+            call_args += ['--config', self._get_configuration(args)]
         return await check_call(
             self.context, call_args, cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -318,13 +318,10 @@ class CmakeBuildTask(TaskExtensionPoint):
         cmd = [CMAKE_EXECUTABLE]
         cmake_ver = get_cmake_version()
         if cmake_ver and cmake_ver >= parse_version('3.15.0'):
-            # CMake 3.15+ supports invoking `cmake --install [--config]
-            #
-            # This only installs, whereas --build <dir> --target install will
-            # build (again) then install.
+            # CMake 3.15+ supports invoking `cmake --install`
             cmd += ['--install', args.build_base]
         else:
-            # Fallback to building the install target.
+            # fallback to the install target which implicitly runs a build
             if not cmake_ver:
                 logger.warning(
                     'Unable to determine CMake version, building the install'

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -324,6 +324,12 @@ class CmakeBuildTask(TaskExtensionPoint):
             cmd += ['--install', args.build_base]
         else:
             # Fallback to building the install target.
+            # Log an error if we are here because we failed to get a meaningful
+            # version number rather than simply using an unsupported version.
+            if not cmake_ver:
+                logger.error(
+                    'Unable to determin CMake version. Fallback to building '
+                    'the install target in place of cmake --install.')
             cmd += ['--build', args.build_base, '--target', 'install']
 
         multi_configuration_generator = is_multi_configuration_generator(

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -315,9 +315,13 @@ class CmakeBuildTask(TaskExtensionPoint):
 
         if CMAKE_EXECUTABLE is None:
             raise RuntimeError("Could not find 'cmake' executable")
+        call_args = [
+            CMAKE_EXECUTABLE, '--build', args.build_base,
+            '--target', 'install']
+        multi_configuration_generator = is_multi_configuration_generator(
+            args.build_base, args.cmake_args)
+        if multi_configuration_generator:
+            call_args.append('--config')
+            call_args.append(self._get_configuration(args))
         return await check_call(
-            self.context,
-            [
-                CMAKE_EXECUTABLE, '--build', args.build_base,
-                '--target', 'install'],
-            cwd=args.build_base, env=env)
+            self.context, call_args, cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -316,20 +316,20 @@ class CmakeBuildTask(TaskExtensionPoint):
             raise RuntimeError("Could not find 'cmake' executable")
 
         cmake_ver = await get_cmake_version()
-        call_args = [ CMAKE_EXECUTABLE ]
+        call_args = [CMAKE_EXECUTABLE]
         if cmake_ver[0] > 3 or cmake_ver[0] == 3 and cmake_ver[1] >= 15:
             # CMake 3.15+ supports invoking `cmake --install [--config]
             # This only installs, whereas --build <dir> --target install will
             # build (again) then install.
-            call_args.extend([ '--install', args.build_base ])
+            call_args.extend(['--install', args.build_base])
         else:
             # Fallback to building the install target.
-            call_args.extend([ '--build', args.build_base,
-                '--target', 'install' ])
+            call_args.extend(['--build', args.build_base,
+                '--target', 'install'])
         # Add configuration for multi-config generators
         multi_configuration_generator = is_multi_configuration_generator(
             args.build_base, args.cmake_args)
         if multi_configuration_generator:
-            call_args.extend([ '--config', self._get_configuration(args) ])
+            call_args.extend(['--config', self._get_configuration(args)])
         return await check_call(
             self.context, call_args, cwd=args.build_base, env=env)

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -317,9 +317,12 @@ class CmakeBuildTask(TaskExtensionPoint):
             raise RuntimeError("Could not find 'cmake' executable")
         cmd = [CMAKE_EXECUTABLE]
         cmake_ver = get_cmake_version()
+        allow_job_args = True
         if cmake_ver and cmake_ver >= parse_version('3.15.0'):
             # CMake 3.15+ supports invoking `cmake --install`
             cmd += ['--install', args.build_base]
+            # Job args not compatible with --install directive
+            allow_job_args = False
         else:
             # fallback to the install target which implicitly runs a build
             if not cmake_ver:
@@ -332,7 +335,7 @@ class CmakeBuildTask(TaskExtensionPoint):
             args.build_base, args.cmake_args)
         if multi_configuration_generator:
             cmd += ['--config', self._get_configuration(args)]
-        else:
+        elif allow_job_args:
             job_args = self._get_make_arguments()
             if job_args:
                 cmd += ['--'] + job_args

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -38,3 +38,5 @@ setuptools
 thomas
 vcxproj
 xcode
+kazys
+stepanas

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -15,6 +15,7 @@ getchildren
 github
 https
 iterdir
+kazys
 kislyuk
 libx
 lstrip
@@ -35,8 +36,7 @@ rtype
 samefile
 scspell
 setuptools
+stepanas
 thomas
 vcxproj
 xcode
-kazys
-stepanas

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -27,17 +27,13 @@ def test_parse_cmake_version():
     ]
 
     # Iterate the strings and parse.
-    for test_item in test_items:
-        parsed_version = _parse_cmake_version_string(test_item[0])
-        expected_ver = test_item[1]
-        # print(test_item[0], ':', parsed_version, 'expected:', expected_ver)
-        if expected_ver is None:
+    for version_string, expected_version in test_items:
+        parsed_version = _parse_cmake_version_string(version_string)
+        if expected_version is None:
             # Input string was garbage. Assert parsing failed.
             assert parsed_version is None
         else:
-            assert parsed_version._version.release[0] == expected_ver[0]
-            assert parsed_version._version.release[1] == expected_ver[1]
-            assert parsed_version._version.release[2] == expected_ver[2]
+            assert parsed_version._version.release[0:3] == expected_version
 
 
 if __name__ == '__main__':

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -1,11 +1,12 @@
+# Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
 from colcon_cmake.task.cmake import parse_cmake_version_string
-from pkg_resources import parse_version
 from pkg_resources.extern.packaging.version import LegacyVersion
 
+
 def test_parse_cmake_version():
-    # Build version prefix string closely matching what cmake --version outputs.
+    # Build version prefix string closely matching what cmake version outputs.
     base_prefix = 'cmake version '
 
     # Expected results list. Each element is a tuple containing the following:
@@ -19,6 +20,10 @@ def test_parse_cmake_version():
         (base_prefix + 'cmake version 3.0.0-rc1-dirty', (3, 0, 0)),
         (base_prefix + 'this.is.garbage', None),
         (base_prefix + '3.15.1', (3, 15, 1)),
+        ('3.15.1', (3, 15, 1)),
+        (base_prefix + '101.202.303-xxx', (101, 202, 303)),
+        ('101.202.303-xxx', (101, 202, 303)),
+        ('prefix 1 number 101.202.303-xxx', (101, 202, 303)),
         ('not the right format', None)
     ]
 
@@ -26,6 +31,7 @@ def test_parse_cmake_version():
     for test_item in test_items:
         parsed_version = parse_cmake_version_string(test_item[0])
         expected_ver = test_item[1]
+        # print(test_item[0], ':', parsed_version, 'expected:', expected_ver)
         if expected_ver is None:
             # Input string was garbage. Assert parsing failed.
             assert parsed_version is None
@@ -33,6 +39,7 @@ def test_parse_cmake_version():
             assert parsed_version._version.release[0] == expected_ver[0]
             assert parsed_version._version.release[1] == expected_ver[1]
             assert parsed_version._version.release[2] == expected_ver[2]
+
 
 if __name__ == "__main__":
     test_parse_cmake_version()

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Dirk Thomas
+# Copyright 2020 Kazys Stepanas
 # Licensed under the Apache License, Version 2.0
 
 from colcon_cmake.task.cmake import _parse_cmake_version_string

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -1,0 +1,43 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import logging
+from pathlib import Path
+import sys
+
+from colcon_cmake.task.cmake import parse_cmake_version_string
+from pkg_resources import parse_version
+from pkg_resources.extern.packaging.version import LegacyVersion
+
+def test_parse_cmake_version():
+    # Build version prefix string closely matching what cmake --version outputs.
+    base_prefix = 'cmake version '
+
+    # Expected results list. Each element is a tuple containing the following:
+    # - Version string to parse.
+    # - Numeric version tuple to compare against (major, minor, patch).
+    # The second item is None where the parse string should not parse.
+    test_items = [
+        (base_prefix + '3.0.0', (3, 0, 0)),
+        (base_prefix + '3.0.0-dirty', (3, 0, 0)),
+        (base_prefix + '3.0.0-rc1', (3, 0, 0)),
+        (base_prefix + 'cmake version 3.0.0-rc1-dirty', (3, 0, 0)),
+        (base_prefix + 'this.is.garbage', None),
+        (base_prefix + '3.15.1', (3, 15, 1)),
+        ('not the right format', None)
+    ]
+
+    # Iterate the strings and parse.
+    for test_item in test_items:
+        parsed_version = parse_cmake_version_string(test_item[0])
+        expected_ver = test_item[1]
+        if expected_ver is None:
+            # Input string was garbage. Assert parsing failed.
+            assert parsed_version is None
+        else:
+            assert parsed_version._version.release[0] == expected_ver[0]
+            assert parsed_version._version.release[1] == expected_ver[1]
+            assert parsed_version._version.release[2] == expected_ver[2]
+
+if __name__ == "__main__":
+    test_parse_cmake_version()

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 from colcon_cmake.task.cmake import parse_cmake_version_string
-from pkg_resources.extern.packaging.version import LegacyVersion
 
 
 def test_parse_cmake_version():
@@ -41,5 +40,5 @@ def test_parse_cmake_version():
             assert parsed_version._version.release[2] == expected_ver[2]
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     test_parse_cmake_version()

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -1,9 +1,4 @@
-# Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
-
-import logging
-from pathlib import Path
-import sys
 
 from colcon_cmake.task.cmake import parse_cmake_version_string
 from pkg_resources import parse_version

--- a/test/test_parse_cmake_version.py
+++ b/test/test_parse_cmake_version.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from colcon_cmake.task.cmake import parse_cmake_version_string
+from colcon_cmake.task.cmake import _parse_cmake_version_string
 
 
 def test_parse_cmake_version():
@@ -28,7 +28,7 @@ def test_parse_cmake_version():
 
     # Iterate the strings and parse.
     for test_item in test_items:
-        parsed_version = parse_cmake_version_string(test_item[0])
+        parsed_version = _parse_cmake_version_string(test_item[0])
         expected_ver = test_item[1]
         # print(test_item[0], ':', parsed_version, 'expected:', expected_ver)
         if expected_ver is None:


### PR DESCRIPTION
Make use of CMake '--install' option introduced in 3.15. Only performs installation, whereas '--build <dir> --target install' would first (re)build. Using '--install' is a significantly faster installation process when using Visual Studio as various overheads are avoided.