### PR TITLE
add minimum version for flake8 to provide extend_ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
   colcon-test-result>=0.3.3
 packages = find:
 tests_require =
-  flake8
+  flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
Same as colcon/colcon-core#260.