### PR TITLE
Use `--cmake-concat-compile-commands` to concatenate multiple compile_commands.json files into a single file

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -59,6 +59,11 @@ class CmakeBuildTask(TaskExtensionPoint):
             '--cmake-force-configure',
             action='store_true',
             help='Force CMake configure step')
+        parser.add_argument(
+            '--cmake-concat-compile-commands',
+            action='store_true',
+            help='Concatenate muliple compile_commands.json into a single '
+                 'file')
 
     async def build(
         self, *, additional_hooks=None, skip_hook_creation=False,

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -63,7 +63,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         parser.add_argument(
             '--cmake-concat-compile-commands',
             action='store_true',
-            help='Concatenate muliple compile_commands.json into a single '
+            help='Concatenate multiple compile_commands.json into a single '
                  'file')
 
     async def build(


### PR DESCRIPTION
Resolved #61

This PR is a draft PR to resolve #61 issue. You can try it by the following command.
```
$ colcon build --cmake-concat-compile-commands --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
$ less build/compile_commands.json
```

It is very useful for me but I know it has no test and the process is not efficient. 
After making this PR, I've noticed that I need to implement a new `colcon` extension/package instead of modifying the `colcon-cmake` package.