### PR TITLE
Add details to CTest test results

### DIFF
--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -98,8 +98,7 @@ class CtestTestResult(TestResultExtensionPoint):
                     result.error_count += 1
 
                 if collect_details and status == 'failed':
-                    lines = []
-                    lines.append('('+child.findtext('Name')+')')
+                    lines = [child.findtext('Name')]
                     lines.extend(
                         _get_messages(
                             'failure message',

--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -96,6 +96,22 @@ class CtestTestResult(TestResultExtensionPoint):
                     result.skipped_count += 1
                 elif status != 'passed':
                     result.error_count += 1
+
+                if collect_details and status == 'failed':
+                    lines = []
+                    lines.append('('+child.findtext('Name')+')')
+                    lines.extend(_get_messages('failure message',
+                        child.findtext('Results/Measurement/Value')))
+                    result.details.append( '\n'.join(lines))
             else:
                 results.add(result)
         return results
+
+def _get_messages(label, message):
+    lines = []
+    if message:
+        lines.append('<<< ' + label)
+        for line in message.strip('\n\r').splitlines():
+            lines.append('  ' + line)
+        lines.append('>>>')
+    return lines

--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -100,12 +100,15 @@ class CtestTestResult(TestResultExtensionPoint):
                 if collect_details and status == 'failed':
                     lines = []
                     lines.append('('+child.findtext('Name')+')')
-                    lines.extend(_get_messages('failure message',
-                        child.findtext('Results/Measurement/Value')))
-                    result.details.append( '\n'.join(lines))
+                    lines.extend(
+                        _get_messages(
+                            'failure message',
+                            child.findtext('Results/Measurement/Value')))
+                    result.details.append('\n'.join(lines))
             else:
                 results.add(result)
         return results
+
 
 def _get_messages(label, message):
     lines = []

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -10,6 +10,7 @@ ctest
 ctests
 dcmake
 etree
+findtext
 getaffinity
 getchildren
 github


### PR DESCRIPTION
before
```
colcon test-result --verbose                        
build/osrf_testing_tools_cpp/Testing/20200212-2242/Test.xml: 4 tests, 0 errors, 1 failure, 0 skipped

Summary: 4 tests, 0 errors, 1 failure, 0 skipped
```
After:
```
colcon test-result --verbose
build/osrf_testing_tools_cpp/Testing/20200212-2242/Test.xml: 4 tests, 0 errors, 1 failure, 0 skipped
- (test_osrf_testing_tools_cpp_filter_versions_cmake)
  <<< failure message
    CMake Error: Error processing file: /opt/ros/master/src/osrf/osrf_testing_tools_cpp/osrf_testing_tools_cpp/test/cmake/test/cmake/test_osrf_testing_tools_cpp_filter_versions.cmake
  >>>

Summary: 4 tests, 0 errors, 1 failure, 0 skipped
```