### PR TITLE
Expose '--ctest-pytest-with-coverage' option

### DIFF
--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -30,6 +30,10 @@ class CmakeTestTask(TaskExtensionPoint):
             help='Pass arguments to CTest projects. '
             'Arguments matching other options must be prefixed by a space,\n'
             'e.g. --ctest-args " --help"')
+        parser.add_argument(
+            '--ctest-pytest-with-coverage',
+            action='store_true',
+            help='Generate coverage information for Python tests')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
         pkg = self.context.pkg
@@ -86,6 +90,9 @@ class CmakeTestTask(TaskExtensionPoint):
             ctest_args += [
                 '--repeat-until-fail', str(count),
             ]
+
+        if args.ctest_pytest_with_coverage:
+            env['AMENT_CMAKE_TEST_PYTEST_COVERAGE_ENABLED'] = ''
 
         rerun = 0
         while True:

--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -92,7 +92,7 @@ class CmakeTestTask(TaskExtensionPoint):
             ]
 
         if args.ctest_pytest_with_coverage:
-            env['AMENT_CMAKE_TEST_PYTEST_COVERAGE_ENABLED'] = ''
+            env['AMENT_CMAKE_TEST_PYTEST_WITH_COVERAGE'] = ''
 
         rerun = 0
         while True:

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,3 +1,4 @@
+ament
 apache
 argcomplete
 basepath


### PR DESCRIPTION
This exposes a `--ctest-pytest-with-coverage` option for `'cmake'` packages. The intent is to use this to generate coverage information for pytest tests with CMake.

Related to  https://github.com/ament/ament_cmake/pull/226