### PR TITLE
add dependency on cmake in Debian package

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-cmake]
 No-Python2:
-Depends3: python3-colcon-core, python3-colcon-library-path, python3-colcon-test-result (>= 0.3.3)
+Depends3: cmake, python3-colcon-core, python3-colcon-library-path, python3-colcon-test-result (>= 0.3.3)
 Suite: xenial bionic focal stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
After installing `colcon-core` from apt, I am unable to build a CMake package despite having `colcon-cmake` installed. For convenience it would be good to have an explicit dependency on `cmake` for the debs of colcon-cmake