### PR TITLE
Exclude test directory from package search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pylint pytest pytest-cov scspell3k
 script:
   # invoke pytest
-  - pytest --cov=colcon_cmake --cov-branch
+  - python -m pytest --cov=colcon_cmake --cov-branch
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,11 +48,6 @@ tests_require =
   scspell3k>=2.2
 zip_safe = true
 
-[options.packages.find]
-exclude =
-  test
-  test.*
-
 [tool:pytest]
 filterwarnings =
     error

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,11 @@ tests_require =
   scspell3k>=2.2
 zip_safe = true
 
+[options.packages.find]
+exclude =
+  test
+  test.*
+
 [tool:pytest]
 filterwarnings =
     error


### PR DESCRIPTION
The files in the `test` directory are getting installed as an additional package.

The `__init__.py` was added in #57, so this bug has existed since 0.2.18.