### PR TITLE
Fix crash under Python3.9

### DIFF
--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -59,15 +59,13 @@ class CtestTestResult(TestResultExtensionPoint):
                 continue
 
             # look for a single 'Testing' child tag
-            try:
-                [testing] = root
-            except ValueError:
+            children = list(root)
+            if len(children) != 1:
                 logger.warning(
                     "Skipping '{latest_xml_path}': 'Site' tag is expected to "
                     '"have exactly one child'.format_map(locals()))
                 continue
-
-            if testing.tag != 'Testing':
+            if children[0].tag != 'Testing':
                 logger.warning(
                     "Skipping '{latest_xml_path}': the child tag is not "
                     "'Testing'".format_map(locals()))
@@ -78,7 +76,7 @@ class CtestTestResult(TestResultExtensionPoint):
 
             # collect information from all 'Test' tags
             result = Result(str(latest_xml_path))
-            for child in testing:
+            for child in children[0]:
                 if child.tag != 'Test':
                     continue
 

--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -59,13 +59,15 @@ class CtestTestResult(TestResultExtensionPoint):
                 continue
 
             # look for a single 'Testing' child tag
-            children = root.getchildren()
-            if len(children) != 1:
+            try:
+                [testing] = root
+            except ValueError:
                 logger.warning(
                     "Skipping '{latest_xml_path}': 'Site' tag is expected to "
                     '"have exactly one child'.format_map(locals()))
                 continue
-            if children[0].tag != 'Testing':
+
+            if testing.tag != 'Testing':
                 logger.warning(
                     "Skipping '{latest_xml_path}': the child tag is not "
                     "'Testing'".format_map(locals()))
@@ -76,7 +78,7 @@ class CtestTestResult(TestResultExtensionPoint):
 
             # collect information from all 'Test' tags
             result = Result(str(latest_xml_path))
-            for child in children[0]:
+            for child in testing:
                 if child.tag != 'Test':
                     continue
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -12,7 +12,6 @@ dcmake
 etree
 findtext
 getaffinity
-getchildren
 github
 https
 iterdir


### PR DESCRIPTION
As per docs:

https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren
```
getchildren()
    Deprecated since version 3.2, will be removed in version 3.9: Use list(elem) or iteration.
```
