### PR TITLE
ensure to reconfigure after failed invocations

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -174,6 +174,12 @@ class CmakeBuildTask(TaskExtensionPoint):
             self.context,
             [CMAKE_EXECUTABLE] + cmake_args,
             cwd=args.build_base, env=env)
+        # in the case CMake fails with an error code make sure to delete the
+        # buildfile if it exists to avoid not running reconfigure next time
+        if completed.returncode:
+            buildfile = get_buildfile(cmake_cache)
+            if buildfile.exists():
+                buildfile.unlink()
         return completed.returncode
 
     def _get_last_cmake_args(self, build_base):


### PR DESCRIPTION
Fixes the following case:

* `cmake` (configuration, no build / test) returns a non-zero error code
* but completes the generation step

E.g. see http://build.ros2.org/view/Fci/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/89/console#console-section-50

<details>
<summary>CMake output</summary>

```
Not searching for unused variables given on the command line.
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/lib/ccache/cc
-- Check for working C compiler: /usr/lib/ccache/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/lib/ccache/c++
-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ament_cmake: 0.8.1 (/tmp/ws/install_isolated/ament_cmake/share/ament_cmake/cmake)
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.2", minimum required is "3") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python3
-- Found rosidl_default_generators: 0.8.0 (/tmp/ws/install_isolated/rosidl_default_generators/share/rosidl_default_generators/cmake)
-- Found rosidl_adapter: 0.8.2 (/tmp/ws/install_isolated/rosidl_adapter/share/rosidl_adapter/cmake)
-- Found PythonInterp: /usr/bin/python3 (found version "3.8.2") 
-- Using single rosidl_typesupport_c: rosidl_typesupport_introspection_c
-- Using single rosidl_typesupport_cpp: rosidl_typesupport_introspection_cpp
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.2", minimum required is "3.5") 
-- Found python_cmake_module: 0.8.0 (/tmp/ws/install_isolated/python_cmake_module/share/python_cmake_module/cmake)
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.8.so (found suitable version "3.8.2", minimum required is "3.5") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python3
-- Using PYTHON_INCLUDE_DIRS: /usr/include/python3.8
-- Using PYTHON_LIBRARIES: /usr/lib/x86_64-linux-gnu/libpython3.8.so
-- Found PythonExtra: .so  
-- Configuring done
CMake Error in CMakeLists.txt:
  Target "builtin_interfaces__rosidl_typesupport_c"
  INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/tmp/ws/build_isolated/builtin_interfaces/rosidl_typesupport_introspection_c"

  which is prefixed in the build directory.


CMake Error: install(EXPORT "builtin_interfaces__rosidl_typesupport_c" ...) includes target "builtin_interfaces__rosidl_typesupport_c" which requires target "builtin_interfaces__rosidl_typesupport_introspection_c" that is not in any export set.
CMake Error in CMakeLists.txt:
  Target "builtin_interfaces__rosidl_typesupport_cpp"
  INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/tmp/ws/build_isolated/builtin_interfaces/rosidl_typesupport_introspection_cpp"

  which is prefixed in the build directory.


CMake Error: install(EXPORT "builtin_interfaces__rosidl_typesupport_cpp" ...) includes target "builtin_interfaces__rosidl_typesupport_cpp" which requires target "builtin_interfaces__rosidl_typesupport_introspection_cpp" that is not in any export set.
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

</details>

Since the `CMakeCache.txt` as well as the `Makefile` are generated successfully a later invocation of `colcon build` will not try to reconfigure the package again. But due to the error that needs to happen.