### PR TITLE
Handle cmake '-G<generator>' syntax

### DIFF
--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -128,8 +128,11 @@ def get_generator(path, cmake_args=None):
     # check for generator in the command line arguments first
     generator = None
     for i, cmake_arg in enumerate(cmake_args or []):
-        if cmake_arg == '-G' and i < len(cmake_args) - 1:
-            generator = cmake_args[i + 1]
+        if cmake_arg[:2] == '-G':
+            if len(cmake_arg) == 2 and i < len(cmake_args) - 1:
+                generator = cmake_args[i + 1]
+            elif len(cmake_arg) > 2:
+                generator = cmake_arg[2:]
     if generator is None:
         # get the generator from the CMake cache
         generator = get_variable_from_cmake_cache(

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -128,11 +128,10 @@ def get_generator(path, cmake_args=None):
     # check for generator in the command line arguments first
     generator = None
     for i, cmake_arg in enumerate(cmake_args or []):
-        if cmake_arg[:2] == '-G':
-            if len(cmake_arg) == 2 and i < len(cmake_args) - 1:
-                generator = cmake_args[i + 1]
-            elif len(cmake_arg) > 2:
-                generator = cmake_arg[2:]
+        if cmake_arg == '-G' and i < len(cmake_args) - 1:
+            generator = cmake_args[i + 1]
+        if cmake_arg.startswith('-G') and len(cmake_arg) > 2:
+            generator = cmake_arg[2:]
     if generator is None:
         # get the generator from the CMake cache
         generator = get_variable_from_cmake_cache(


### PR DESCRIPTION
CMake supports generators specified using '-G <generator>' (2 arguments) or as '-G<generator>' (1 argument). This change adds colcon support for the latter, one argument syntax.