### PR TITLE
Pass string paths instead of PosixPath

### DIFF
--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -139,8 +139,8 @@ class CmakeTestTask(TaskExtensionPoint):
 
             dst = Path(args.test_result_base) / 'Testing' / latest_xml_dir
             dst.mkdir(parents=True, exist_ok=True)
-            _copy_file(tag_file, str(dst.parent / tag_file.name))
-            _copy_file(latest_xml_path, str(dst / latest_xml_path.name))
+            _copy_file(str(tag_file), str(dst.parent / tag_file.name))
+            _copy_file(str(latest_xml_path), str(dst / latest_xml_path.name))
 
     def _get_configuration_from_cmake(self, build_base):
         # get for CMake build type from the CMake cache


### PR DESCRIPTION
After https://github.com/colcon/colcon-cmake/commit/c9a13a63d2a3cb0f58a165ae5828c9d433fa187f was merged, running `colcon test` with `--test-result-base` fails with:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/executor/__init__.py", line 91, in __call__
    rc = await self.task(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/colcon_core/task/__init__.py", line 93, in __call__
    return await task_method(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/colcon_ros/task/catkin/test.py", line 53, in test
    return await extension.test()
  File "/usr/lib/python3/dist-packages/colcon_cmake/task/cmake/test.py", line 143, in test
    _copy_file(latest_xml_path, str(dst / latest_xml_path.name))
  File "/usr/lib/python3/dist-packages/colcon_cmake/task/cmake/test.py", line 160, in _copy_file
    shutil.copy2(src, dst)
  File "/usr/lib/python3.5/shutil.py", line 251, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 97, in copyfile
    if _samefile(src, dst):
  File "/usr/lib/python3.5/shutil.py", line 82, in _samefile
    return os.path.samefile(src, dst)
  File "/usr/lib/python3.5/genericpath.py", line 90, in samefile
    s1 = os.stat(f1)
TypeError: argument should be string, bytes or integer, not PosixPath
```

This is due paths being passed as pathlib objects instead of strings, this PR fixes the issue. cc: @paulbovbel
