### PR TITLE
Use command environment for determining MAKE args

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -287,7 +287,7 @@ class CmakeBuildTask(TaskExtensionPoint):
 
         The arguments are chosen based on the `cpu_count`, e.g. -j4 -l4.
 
-        :param env: a dictionary with environment variables
+        :param dict env: a dictionary with environment variables
         :returns: list of make arguments
         :rtype: list of strings
         """

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -241,7 +241,7 @@ class CmakeBuildTask(TaskExtensionPoint):
             if multi_configuration_generator:
                 cmd += ['--config', self._get_configuration(args)]
             else:
-                job_args = self._get_make_arguments()
+                job_args = self._get_make_arguments(env)
                 if job_args:
                     cmd += ['--'] + job_args
             completed = await run(
@@ -281,17 +281,18 @@ class CmakeBuildTask(TaskExtensionPoint):
             env['CL'] = ' '.join(cl_split)
         return env
 
-    def _get_make_arguments(self):
+    def _get_make_arguments(self, env):
         """
         Get the make arguments to limit the number of simultaneously run jobs.
 
         The arguments are chosen based on the `cpu_count`, e.g. -j4 -l4.
 
+        :param env: a dictionary with environment variables
         :returns: list of make arguments
         :rtype: list of strings
         """
         # check MAKEFLAGS for -j/--jobs/-l/--load-average arguments
-        makeflags = os.environ.get('MAKEFLAGS', '')
+        makeflags = env.get('MAKEFLAGS', '')
         regex = (
             r'(?:^|\s)'
             r'(-?(?:j|l)(?:\s*[0-9]+|\s|$))'
@@ -343,7 +344,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         if multi_configuration_generator:
             cmd += ['--config', self._get_configuration(args)]
         elif allow_job_args:
-            job_args = self._get_make_arguments()
+            job_args = self._get_make_arguments(env)
             if job_args:
                 cmd += ['--'] + job_args
         return await run(


### PR DESCRIPTION
Instead of grabbing the colcon process environment variables to determine what MAKEFLAGS will be when the process is invoked, grab the actual environment variables under which MAKE will be invoked.