### PR TITLE
Suppress DESTDIR environment variable in CMake operations

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -84,6 +84,8 @@ class CmakeBuildTask(TaskExtensionPoint):
         if environment_callback is not None:
             environment_callback(env)
 
+        env.pop('DESTDIR', None)
+
         rc = await self._reconfigure(args, env)
         if rc:
             return rc

--- a/colcon_cmake/task/cmake/test.py
+++ b/colcon_cmake/task/cmake/test.py
@@ -52,6 +52,8 @@ class CmakeTestTask(TaskExtensionPoint):
             logger.error(str(e))
             return 1
 
+        env.pop('DESTDIR', None)
+
         if CTEST_EXECUTABLE is None:
             raise RuntimeError("Could not find 'ctest' executable")
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -10,6 +10,7 @@ contextlib
 ctest
 ctests
 dcmake
+destdir
 etree
 findtext
 getaffinity


### PR DESCRIPTION
The `DESTDIR` environment variable is a well-documented mechanism used on UNIX systems to prefix the installation directory with another path during an invocation of `make install`. There are four reasons that colcon should never allow that variable to be passed when `make` might be invoked:
1. The behavior is not consistent across all of the platforms that colcon supports, which could mean that Linux behaves different from Windows.
2. Specifying `DESTDIR` during a build phase could have unintended consequences if the project isn't properly structured.
3. Other colcon package types (like Python) may not support `DESTDIR`, resulting in inconsistent behavior even within the same build invocation.
4. colcon is already using the more platform-agnostic `CMAKE_INSTALL_PREFIX` to set the installation directory, and both mechanisms would affect the final installation directory simultaneously.

Given that the widely adopted spirit of `DESTDIR` is to augment the installation directory on some systems, this change hides the variable for all CMake operations.

If there is desire for `DESTDIR` to augment the behavior of colcon in any way, it should be supported consistently on all platforms by all supported package types. Really, though, the supported mechanism for augmenting the installation directory (--install-base) is the right way to do this.