### PR TITLE
Add support for `Ninja Multi-Config`

### DIFF
--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -55,7 +55,7 @@ async def has_target(path, target):
     generator = get_generator(path)
     if 'Unix Makefiles' in generator:
         return target in await get_makefile_targets(path)
-    if 'Ninja' in generator or 'Ninja Multi-Config' in generator:
+    if 'Ninja' in generator:
         return target in get_ninja_targets(path)
     if 'Visual Studio' in generator:
         assert target == 'install'

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -109,7 +109,7 @@ def get_buildfile(cmake_cache):
     """
     generator = get_variable_from_cmake_cache(
         str(cmake_cache.parent), 'CMAKE_GENERATOR')
-    if generator == 'Ninja':
+    if 'Ninja' in generator:
         return cmake_cache.parent / 'build.ninja'
     return cmake_cache.parent / 'Makefile'
 

--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -55,7 +55,7 @@ async def has_target(path, target):
     generator = get_generator(path)
     if 'Unix Makefiles' in generator:
         return target in await get_makefile_targets(path)
-    if 'Ninja' in generator:
+    if 'Ninja' in generator or 'Ninja Multi-Config' in generator:
         return target in get_ninja_targets(path)
     if 'Visual Studio' in generator:
         assert target == 'install'
@@ -148,6 +148,7 @@ def is_multi_configuration_generator(path, cmake_args=None):
     :rtype: bool
     """
     known_multi_configuration_generators = (
+        'Ninja Multi-Config',
         'Visual Studio',
         'Xcode',
     )


### PR DESCRIPTION
The `Ninja Multi-Config` generator was introduced as part of CMake 3.17 supporting debug and release artefacts under the same `build` directory, like `Xcode` or `Visual Studio`. This change allows colcon to recognise `Ninja Multi-Config` as a mult-config generator and as a Ninja generator.

Note that in practice this change does not support an `apt-get` install of CMake on versions of current Ubuntu LTS releases - Unbutu 20.04 (latest current LTS) provided CMake version 3.16.

Change summary:

- Add `Ninja Multi-Config` to the set of generators where `is_multi_configuration_generator()` is `True`
