### PR TITLE
suppress deprecation warning in flake8

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -64,10 +64,10 @@ class CmakeBuildTask(TaskExtensionPoint):
             action='store_true',
             help='Force CMake configure step')
 
-    async def build(
+    async def build(  # noqa: D102
         self, *, additional_hooks=None, skip_hook_creation=False,
         environment_callback=None, additional_targets=None
-    ):  # noqa: D102
+    ):
         pkg = self.context.pkg
         args = self.context.args
 

--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -26,9 +26,9 @@ class CtestTestResult(TestResultExtensionPoint):
         satisfies_version(
             TestResultExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
-    def get_test_results(
+    def get_test_results(  # noqa: D102
         self, basepath, *, collect_details, files=None
-    ):  # noqa: D102
+    ):
         results = set()
         # check all 'TAG' files in a directory named 'Testing'
         for tag_file in basepath.glob('**/Testing/TAG'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ zip_safe = true
 [tool:pytest]
 filterwarnings =
     error
+    # Suppress deprecation warning in flake8
+    ignore:SelectableGroups dict interface is deprecated::flake8
 junit_suite_name = colcon-cmake
 
 [options.entry_points]


### PR DESCRIPTION
Introduced by python/importlib_metadata # 298.

Move `noqa` comments to pass latest version of `flake8`.

Closes #108.