### PR TITLE
Specify buildfile for Visual Studio generator

### DIFF
--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -111,6 +111,8 @@ def get_buildfile(cmake_cache):
         str(cmake_cache.parent), 'CMAKE_GENERATOR')
     if 'Ninja' in generator:
         return cmake_cache.parent / 'build.ninja'
+    if 'Visual Studio' in generator:
+        return cmake_cache.parent / 'ALL_BUILD.vcxproj'
     return cmake_cache.parent / 'Makefile'
 
 


### PR DESCRIPTION
This specifies a buildfile for the Visual Studio generator, so cmake will not always reconfigure.

Fixes #111