### PR TITLE
Add support for just configuring cmake projects

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -60,6 +60,10 @@ class CmakeBuildTask(TaskExtensionPoint):
             help="Build target 'clean' first, then build (to only clean use "
                  "'--cmake-target clean')")
         parser.add_argument(
+            '--cmake-configure-only',
+            action='store_true',
+            help='Stop after configuring cmake without building any targets')
+        parser.add_argument(
             '--cmake-force-configure',
             action='store_true',
             help='Force CMake configure step')
@@ -72,7 +76,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         args = self.context.args
 
         logger.info(
-            "Building CMake package in '{args.path}'".format_map(locals()))
+            "Configuring CMake package in '{args.path}'".format_map(locals()))
 
         try:
             env = await get_command_environment(
@@ -99,7 +103,15 @@ class CmakeBuildTask(TaskExtensionPoint):
                 .format_map(locals())
             )
             return
-
+        
+        if args.cmake_configure_only:
+            logger.info(
+                "Successfully configured CMake package: '{project_name}'".format_map(locals()))
+            return
+        
+        logger.info(
+            "Building CMake package: '{project_name}'".format_map(locals()))
+        
         rc = await self._build(
             args, env, additional_targets=additional_targets)
         if rc:

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -103,15 +103,17 @@ class CmakeBuildTask(TaskExtensionPoint):
                 .format_map(locals())
             )
             return
-        
+
         if args.cmake_configure_only:
             logger.info(
-                "Successfully configured CMake package: '{project_name}'".format_map(locals()))
+                "Successfully configured CMake package: '{project_name}'"
+                .format_map(locals())
+            )
             return
-        
+
         logger.info(
             "Building CMake package: '{project_name}'".format_map(locals()))
-        
+
         rc = await self._build(
             args, env, additional_targets=additional_targets)
         if rc:


### PR DESCRIPTION
Fixes #116

1. Made the new argument the penultimate one so as to not interfere with other PRs
2. Don't really know how to handle `rc`
3. Put the log messages after identifying the project name (can also not use it, but it felt proper to use the name)