### PR TITLE
Support specifying any number of specific CMake targets

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,5 +1,6 @@
 apache
 argcomplete
+argparse
 basepath
 buildfile
 cmake


### PR DESCRIPTION
This change deprecates the single-value --cmake-target argument in favor of one that allows any number of targets to be specified, including no targets at all.

This will require a corresponding change in `colcon_ros` to use the new arguments.