### PR TITLE
Fix TypeError when CMAKE_GENERATOR isn't present

### DIFF
--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -109,7 +109,7 @@ def get_buildfile(cmake_cache):
     """
     generator = get_variable_from_cmake_cache(
         str(cmake_cache.parent), 'CMAKE_GENERATOR')
-    if 'Ninja' in generator:
+    if generator and 'Ninja' in generator:
         return cmake_cache.parent / 'build.ninja'
     return cmake_cache.parent / 'Makefile'
 


### PR DESCRIPTION
While building, I received this error at the line corrected:
```TypeError: argument of type 'NoneType' is not iterable```

This happens because get_variable_from_cmake_cache() returns None. This line fixes it.