### PR TITLE
Add the --cmake-build-args options

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -69,8 +69,7 @@ class CmakeBuildTask(TaskExtensionPoint):
             nargs='*',
             help='Pass arguments to cmake --build. '
             'Arguments matching other options must be prefixed by a space,\n'
-            'e.g. --cmake-args " --help" (stdout might not be shown by '
-            'default, e.g. add `--event-handlers console_cohesion+`)')
+            'e.g. --cmake-build-args " --parallel" 4')
 
     async def build(  # noqa: D102
         self, *, additional_hooks=None, skip_hook_creation=False,

--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -64,6 +64,13 @@ class CmakeBuildTask(TaskExtensionPoint):
             '--cmake-force-configure',
             action='store_true',
             help='Force CMake configure step')
+        parser.add_argument(
+            "--cmake-build-args", metavar='*', type=str.lstrip,
+            nargs='*',
+            help='Pass arguments to cmake --build. '
+            'Arguments matching other options must be prefixed by a space,\n'
+            'e.g. --cmake-args " --help" (stdout might not be shown by '
+            'default, e.g. add `--event-handlers console_cohesion+`)')
 
     async def build(  # noqa: D102
         self, *, additional_hooks=None, skip_hook_creation=False,
@@ -237,6 +244,8 @@ class CmakeBuildTask(TaskExtensionPoint):
                 cmd += ['--clean-first']
             if multi_configuration_generator:
                 cmd += ['--config', self._get_configuration(args)]
+            if args.cmake_build_args:
+                cmd += args.cmake_build_args
             else:
                 job_args = self._get_make_arguments(env)
                 if job_args:


### PR DESCRIPTION
This allows the user to pass arguments to the cmake --build invocation, and bypass the automatic -j -l arguments.

Note that I changed the logic of the `if multi_configuration_generator: ... else: # add jobs args`: I don't see why the addition of `--config` should prevent the addition of the job arguments.

Closes #141.