### PR TITLE
Fix (another) TypeError when CMAKE_GENERATOR isn't present

### DIFF
--- a/colcon_cmake/task/cmake/__init__.py
+++ b/colcon_cmake/task/cmake/__init__.py
@@ -109,10 +109,11 @@ def get_buildfile(cmake_cache):
     """
     generator = get_variable_from_cmake_cache(
         str(cmake_cache.parent), 'CMAKE_GENERATOR')
-    if generator and 'Ninja' in generator:
-        return cmake_cache.parent / 'build.ninja'
-    if 'Visual Studio' in generator:
-        return cmake_cache.parent / 'ALL_BUILD.vcxproj'
+    if generator is not None:
+        if 'Ninja' in generator:
+            return cmake_cache.parent / 'build.ninja'
+        if 'Visual Studio' in generator:
+            return cmake_cache.parent / 'ALL_BUILD.vcxproj'
     return cmake_cache.parent / 'Makefile'
 
 


### PR DESCRIPTION
In what I can only call an absolute blunder, `colcon-cmake` 0.2.28 included both a change to fix this exception (#128) and a subsequent change which added the same bug (#114). I failed to connect the dots :facepalm:

Thanks to @FelixPe for [pointing this out](https://github.com/colcon/colcon-cmake/pull/114#issuecomment-2309823537).