### PR TITLE
If available, use CMake file API to discover targets

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import re
 
+from colcon_cmake.task.cmake import add_api_queries
 from colcon_cmake.task.cmake import CMAKE_EXECUTABLE
 from colcon_cmake.task.cmake import get_buildfile
 from colcon_cmake.task.cmake import get_cmake_version
@@ -172,6 +173,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         if CMAKE_EXECUTABLE is None:
             raise RuntimeError("Could not find 'cmake' executable")
         os.makedirs(args.build_base, exist_ok=True)
+        add_api_queries(args.build_base)
         completed = await run(
             self.context,
             [CMAKE_EXECUTABLE] + cmake_args,

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -6,6 +6,7 @@ basepath
 buildfile
 cmake
 cmakelists
+codemodel
 colcon
 completers
 contextlib


### PR DESCRIPTION
The [CMake file API](https://cmake.org/cmake/help/v3.14/manual/cmake-file-api.7.html) was added in CMake 3.14. It can be used (among other things) to get a list of targets for the project that was configured. In my local tests, this appears to be significantly faster than crafting a special invocation of the generator and should also work the same for any generator.

This change attempts to use the API, but falls back to the existing behavior if it doesn't work (possibly because of an older CMake version).