### PR TITLE
Switch implicit make flags to use GNUMAKEFLAGS var

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -13,9 +13,11 @@ ctest
 ctests
 dcmake
 etree
+finditer
 findtext
 getaffinity
 github
+gnumakeflags
 https
 iterdir
 kazys


### PR DESCRIPTION
There are a few notable elements addressed by this change:
1. The --load/-l argument is GNU-only and doesn't work on BSD make
2. The GNUMAKEFLAGS environment variable was previously ignored when looking for existing make arguments
3. By passing the flags via command line arguments to CMake's build invocation, the makeflags were sometimes omitted due to incompatibility.

Until I can come up with some tests for this, I'll keep this PR in draft.