### PR TITLE
Fix return value from CMAKE_MODULE_PATH hook

### DIFF
--- a/colcon_cmake/environment/cmake_module_path.py
+++ b/colcon_cmake/environment/cmake_module_path.py
@@ -44,7 +44,7 @@ class CmakeModulePathEnvironment(EnvironmentExtensionPoint):
                         str(path.relative_to(prefix_path)),
                         mode='prepend')
 
-        return hooks.values()
+        return [hook for hook_list in hooks.values() for hook in hook_list]
 
     def _get_potential_cmake_module_paths(self, prefix_path, pkg_name):
         paths = []


### PR DESCRIPTION
This was a regression introduced by  #20 which was hidden by some nuanced API characteristics for environment hook extensions, which would manifest as silently missing environment hooks for CMAKE_MODULE_PATH.