### PR TITLE
test_result: skip gtest summaries to reduce number of duplicates in output

### DIFF
--- a/colcon_cmake/test_result/ctest.py
+++ b/colcon_cmake/test_result/ctest.py
@@ -3,6 +3,7 @@
 
 from xml.etree.ElementTree import ElementTree
 
+from colcon_core.extension_point import get_all_extension_points
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_test_result.test_result import Result
@@ -25,6 +26,7 @@ class CtestTestResult(TestResultExtensionPoint):
         super().__init__()
         satisfies_version(
             TestResultExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        self.xunit_extension_installed = "xunit" in get_all_extension_points()["colcon_test_result.test_result"].keys()
 
     def get_test_results(  # noqa: D102
         self, basepath, *, collect_details, files=None
@@ -80,8 +82,6 @@ class CtestTestResult(TestResultExtensionPoint):
                 if child.tag != 'Test':
                     continue
 
-                result.test_count += 1
-
                 try:
                     status = child.attrib['Status']
                 except KeyError:
@@ -89,6 +89,18 @@ class CtestTestResult(TestResultExtensionPoint):
                         f"Skipping '{latest_xml_path}': a 'test' tag lacks a "
                         "'Status' attribute")
                     break
+
+                name = child.findtext('Name')
+
+                # Skip tests which are labeled as gtest if the "xunit" extension is also installed.
+                # Gtest generates an xunit file containing all individual test cases, so don't add +1 for the ctest summary here.
+                if self.xunit_extension_installed:
+                    labels = child.find("Labels") or []
+                    if ("gtest" in [l.text for l in labels]):
+                        logger.debug(f"Skipping '{name}' in '{latest_xml_path}': gtest has own result file.")
+                        continue
+
+                result.test_count += 1
 
                 if status == 'failed':
                     result.failure_count += 1
@@ -98,14 +110,15 @@ class CtestTestResult(TestResultExtensionPoint):
                     result.error_count += 1
 
                 if collect_details and status == 'failed':
-                    lines = [child.findtext('Name')]
+                    lines = [name]
                     lines.extend(
                         _get_messages(
                             'failure message',
                             child.findtext('Results/Measurement/Value')))
                     result.details.append('\n'.join(lines))
             else:
-                results.add(result)
+                if result.test_count > 0:
+                    results.add(result)
         return results
 
 


### PR DESCRIPTION
This fixes the issue reported in https://github.com/colcon/colcon-test-result/issues/44, of gtest results being shown both from the xunit report generated by gtest itself, and the ctest report of executing the entire gtest executable.

I'm not sure if this is actually good, one downside is that the full gtest output (including for example stdout of the test) is not shown anymore, as this is only included in the ctest report. The gtest xunit report only contains the error message. I found this not very problematic and the tradeoff worthwile, as the gtest output recorded in the ctest report is not very useful anyways because it strips any color. `GTEST_COLOR=1 colcon test (--packges-select ...) --event-handlers console_cohesion+` is the only useful way for me to get this.

I think it might be worthwhile to special-case this, as it is a very common and often the first type of test added to a ROS package, and the colcon testing workflow is confusing enough already...