### PR TITLE
Support Visual Studio 2026

### DIFF
--- a/colcon_cmake/task/cmake/build.py
+++ b/colcon_cmake/task/cmake/build.py
@@ -152,6 +152,7 @@ class CmakeBuildTask(TaskExtensionPoint):
                     'VisualStudioVersion is not set, '
                     'please run within a Visual Studio Command Prompt.')
             supported_vsv = {
+                '18.0': 'Visual Studio 18 2026',
                 '17.0': 'Visual Studio 17 2022',
                 '16.0': 'Visual Studio 16 2019',
                 '15.0': 'Visual Studio 15 2017',


### PR DESCRIPTION
This PR updates the dictionary of supported versions of Visual Studio. `windows-latest` images on GitHub now ship with Visual Studio 2026 starting June 8th 2026 (https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners)

Fixes #155